### PR TITLE
Fix to passing excel kwargs

### DIFF
--- a/src/healdata_utils/io.py
+++ b/src/healdata_utils/io.py
@@ -82,6 +82,8 @@ def read_excel(filepath,sheet_names=None,castdtype="string"):
     
     This is akin to pandas.read_excel when all sheet_names (or sheet_name=None)
     is specified EXCEPT that the default is each value is the string representation.
+    Additionally, if only one sheet exists (even if passing a list), it will output
+    a datframe rather than a dict of dataframes.
 
     See the dtype arg in pandas read_excel docs for more info.
 
@@ -96,13 +98,14 @@ def read_excel(filepath,sheet_names=None,castdtype="string"):
     if isinstance(sheet_names,list):
         selected_sheet_names = [sheet for sheet in book.sheet_names 
             if sheet in sheet_names]
-    elif isinstance(sheet_names,str):
+    elif isinstance(sheet_names,(str,int)):
         selected_sheet_names = [sheet_names]
     else:
         selected_sheet_names = book.sheet_names
 
 
     if len(selected_sheet_names) == 1:
+        sheet = selected_sheet_names[0]
         df = pd.read_excel(book,sheet_name=sheet,dtype=castdtype).fillna("")
         return df
     else:

--- a/src/healdata_utils/transforms/excel/conversion.py
+++ b/src/healdata_utils/transforms/excel/conversion.py
@@ -1,13 +1,13 @@
 from healdata_utils.io import read_excel,pd
 from healdata_utils.types import typesets
 from healdata_utils.transforms.jsontemplate.conversion import convert_templatejson
-def convert_dataexcel(file_path,sheet_name=None,multiple_data_dicts=True,**kwargs):
+def convert_dataexcel(file_path,data_dictionary_props=None,sheet_name=None,multiple_data_dicts=True):
     """ 
     converts a file or file like object (eg pandas.ExcelFile) into a data dictionary
     package or a dict of data_dictionary packages
 
     file_path: str - path to xlsx file
-    sheet_names: Union[str,list,None]. By default (None), all sheets are read and a dict
+    sheet_name: Union[str,list,None]. By default (None), all sheets are read and a dict
         of data frame is returned. If a list of sheets is provided, also returns a dict of packages. Else, returns 
     multiple_data_dicts, boolean: if each sheet represents one data resource 
         (ie if False, all sheets will be concatenated before inference)


### PR DESCRIPTION
Tests did not include kwargs for excel (as it was geared towards CLI which doesn't use kwargs at the moment).  However, other use cases require these kwargs so this is an important fix.