### PR TITLE
Add missing ranges (another way to specify missing values in SPSS)

### DIFF
--- a/src/healdata_utils/transforms/readstat/conversion.py
+++ b/src/healdata_utils/transforms/readstat/conversion.py
@@ -94,6 +94,10 @@ def convert_readstat(file_path,
                     missing_values.append(str(values[0]))
                 else:
                     missing_values.append(values[0])
+            # missing_ranges is in readstat for spss
+            elif list(items.keys()) == ["lo","hi"]:
+                values = list(range(int(items["lo"]),int(items["hi"])+1))
+                missing_values.extend(values)
             else:
                 raise Exception("Currently, only discrete values are supported")
 


### PR DESCRIPTION
Previously, if user specified, the code would raise an exception -- generally, users don't make use of this feature but a HEAL investigator has this for one of their variables so adding now